### PR TITLE
GHA-0006 terraform state management and deriving infra cost max cost dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,65 @@
-# GitHub Action Template Repository
+# 🚀 Infracost GitHub Action
 
 ![Release](https://github.com/subhamay-bhattacharyya-gha/infracost-action/actions/workflows/release.yaml/badge.svg)&nbsp;![Commit Activity](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Last Commit](https://img.shields.io/github/last-commit/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Release Date](https://img.shields.io/github/release-date/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Repo Size](https://img.shields.io/github/repo-size/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![File Count](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Issues](https://img.shields.io/github/issues/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Top Language](https://img.shields.io/github/languages/top/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Custom Endpoint](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/68d0048cc82fdd049535383c9b836ec7/raw/infracost-action.json?)
 
-A Template GitHub Repository to be used to create a composite action.
-
-## Action Name
-
-### Action Description
-
-This GitHub Action provides a reusable composite workflow that sets up Python and interacts with the GitHub API to post a comment on an issue, including a link to a created branch.
+This GitHub Action downloads a Terraform plan artifact and runs [Infracost](https://www.infracost.io/) to generate a cost estimate. It supports use cases where plans are generated in a separate workflow and reused across CI/CD stages.
 
 ---
 
-## Inputs
+## 🧾 Inputs
 
-| Name           | Description         | Required | Default        |
-|----------------|---------------------|----------|----------------|
-| `input-1`      | Input description.  | No       | `default-value`|
-| `input-2`      | Input description.  | No       | `default-value`|
-| `input-3`      | Input description.  | No       | `default-value`|
-| `github-token` | GitHub token. Used for API authentication. | Yes | — |
+| Name              | Description                                                                 |
+|-------------------|-----------------------------------------------------------------------------|
+| `terraform-dir`   | Relative path to the Terraform directory (e.g., `tf`, `infrastructure`).    |
+| `release-tag`     | Git release tag to check out. If omitted, the latest commit is used.        |
+| `ci-pipeline`     | If `true`, includes the commit SHA in the Terraform state key.              |
+| `s3-bucket`       | Name of the S3 bucket used for the Terraform state backend.                 |
+| `s3-region`       | AWS region where the S3 backend bucket is located (e.g., `us-east-1`).      |
+| `tf-plan-name`    | Name of the Terraform plan artifact.                                        |
+| `tf-plan-file`    | Base filename (without extension) for the Terraform plan output.            |
+| `tf-vars-file`    | Optional Terraform variable file.                                           |
+| `infracost-api-key` | Infracost API key.                                                        |
+| `max-cost`        | Optional cost threshold. Fails if monthly cost exceeds this (e.g., `100.00`).|
 
 ---
 
-## Example Usage
+## 📤 Outputs
+
+| Name            | Description                               |
+|------------------|-------------------------------------------|
+| `monthly-cost`   | Total monthly cost calculated by Infracost.|
+
+---
+
+## 💡 Example Usage
 
 ```yaml
-name: Example Workflow
+name: Infracost Breakdown
 
 on:
-  issues:
-    types: [opened]
+  workflow_dispatch:
 
 jobs:
-  example:
+  infracost:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run Custom Action
-        uses: your-org/your-action-repo@v1
+      - name: Run Infracost Analysis
+        uses: subhamay-bhattacharyya-gha/infracost-action@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          input-1: your-value
-          input-2: another-value
-          input-3: something-else
+          terraform-dir: tf
+          release-tag: ""
+          ci-pipeline: "true"
+          s3-bucket: my-terraform-state-bucket
+          s3-region: us-east-1
+          tf-plan-name: terraform-plan
+          tf-plan-file: tfplan
+          tf-vars-file: terraform.tfvars
+          infracost-api-key: ${{ secrets.INFRACOST_API_KEY }}
+          max-cost: "100.00"
+
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,33 +1,47 @@
 # 🚀 Infracost GitHub Action
 
-![Release](https://github.com/subhamay-bhattacharyya-gha/infracost-action/actions/workflows/release.yaml/badge.svg)&nbsp;![Commit Activity](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Last Commit](https://img.shields.io/github/last-commit/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Release Date](https://img.shields.io/github/release-date/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Repo Size](https://img.shields.io/github/repo-size/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![File Count](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Issues](https://img.shields.io/github/issues/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Top Language](https://img.shields.io/github/languages/top/subhamay-bhattacharyya-gha/infracost-action)&nbsp;![Custom Endpoint](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/68d0048cc82fdd049535383c9b836ec7/raw/infracost-action.json?)
+![Release](https://github.com/subhamay-bhattacharyya-gha/infracost-action/actions/workflows/release.yaml/badge.svg)&nbsp;
+![Commit Activity](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya-gha/infracost-action)&nbsp;
+![Last Commit](https://img.shields.io/github/last-commit/subhamay-bhattacharyya-gha/infracost-action)&nbsp;
+![Release Date](https://img.shields.io/github/release-date/subhamay-bhattacharyya-gha/infracost-action)&nbsp;
+![Repo Size](https://img.shields.io/github/repo-size/subhamay-bhattacharyya-gha/infracost-action)&nbsp;
+![File Count](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya-gha/infracost-action)&nbsp;
+![Issues](https://img.shields.io/github/issues/subhamay-bhattacharyya-gha/infracost-action)&nbsp;
+![Top Language](https://img.shields.io/github/languages/top/subhamay-bhattacharyya-gha/infracost-action)&nbsp;
+![Custom Endpoint](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/68d0048cc82fdd049535383c9b836ec7/raw/infracost-action.json?)
 
-This GitHub Action downloads a Terraform plan artifact and runs [Infracost](https://www.infracost.io/) to generate a cost estimate. It supports use cases where plans are generated in a separate workflow and reused across CI/CD stages.
+This GitHub Action downloads a Terraform plan artifact and runs [Infracost](https://www.infracost.io/) to generate a cost estimate. It supports workflows where the Terraform plan is created in a separate job or workflow, and reused across CI/CD stages.
+
+It also supports dynamic cost thresholding (`max_cost`) using a GitHub Gist that maps environments and repositories to their cost budgets.
 
 ---
 
 ## 🧾 Inputs
 
-| Name              | Description                                                                 |
-|-------------------|-----------------------------------------------------------------------------|
-| `terraform-dir`   | Relative path to the Terraform directory (e.g., `tf`, `infrastructure`).    |
-| `release-tag`     | Git release tag to check out. If omitted, the latest commit is used.        |
-| `ci-pipeline`     | If `true`, includes the commit SHA in the Terraform state key.              |
-| `s3-bucket`       | Name of the S3 bucket used for the Terraform state backend.                 |
-| `s3-region`       | AWS region where the S3 backend bucket is located (e.g., `us-east-1`).      |
-| `tf-plan-name`    | Name of the Terraform plan artifact.                                        |
-| `tf-plan-file`    | Base filename (without extension) for the Terraform plan output.            |
-| `tf-vars-file`    | Optional Terraform variable file.                                           |
-| `infracost-api-key` | Infracost API key.                                                        |
-| `max-cost`        | Optional cost threshold. Fails if monthly cost exceeds this (e.g., `100.00`).|
+| Name                | Description                                                                 |
+|---------------------|-----------------------------------------------------------------------------|
+| `terraform-dir`     | Relative path to the Terraform directory (e.g., `tf`, `infrastructure`).    |
+| `release-tag`       | Git release tag to check out. If omitted, the latest commit is used.        |
+| `ci-pipeline`       | If `true`, includes the commit SHA in the Terraform state key.              |
+| `s3-bucket`         | Name of the S3 bucket used for the Terraform state backend.                 |
+| `s3-region`         | AWS region where the S3 backend bucket is located (e.g., `us-east-1`).      |
+| `tf-plan-name`      | Name of the Terraform plan artifact.                                        |
+| `tf-plan-file`      | Base filename (without extension) for the Terraform plan output.            |
+| `tf-vars-file`      | Optional Terraform variable file.                                           |
+| `infracost-api-key` | Infracost API key.                                                          |
+| `gist-id`           | Gist ID containing the Infracost configuration (e.g., repository/env → max cost). |
+| `gist-filename`     | Gist filename (default: `infracost-config.json`).                           |
+| `environment`       | GitHub environment name (e.g., `dev`, `test`, `prod`) used to look up max cost. |
+| `max-cost`          | Optional fallback cost threshold. Used if not found in Gist (e.g., `100.00`).|
 
 ---
 
 ## 📤 Outputs
 
-| Name            | Description                               |
-|------------------|-------------------------------------------|
-| `monthly-cost`   | Total monthly cost calculated by Infracost.|
+| Name            | Description                                                     |
+|------------------|-----------------------------------------------------------------|
+| `monthly-cost`   | Total monthly cost calculated by Infracost.                     |
+| `max-cost`       | Resolved maximum cost threshold from Gist or fallback value.    |
 
 ---
 
@@ -58,10 +72,31 @@ jobs:
           tf-plan-file: tfplan
           tf-vars-file: terraform.tfvars
           infracost-api-key: ${{ secrets.INFRACOST_API_KEY }}
-          max-cost: "100.00"
-
+          gist-id: ${{ secrets.infracost-gist-id }}
+          gist-filename: ${{ secrets.gist-filename }}
+          environment: devl
 ```
 
-## License
+## 🧠 Gist JSON Format Example
+
+```json
+{
+  "0002-terraform-template": {
+    "ci": { "max_cost": 1.99 },
+    "devl": { "max_cost": 1.00 },
+    "test": { "max_cost": 20.00 },
+    "prod": { "max_cost": 80.00 }
+  },
+  "data-lake": {
+    "devl": { "max_cost": 4.00 },
+    "test": { "max_cost": 10.00 },
+    "prod": { "max_cost": 100.00 }
+  }
+}
+```
+
+---
+
+## 🪪 License
 
 MIT

--- a/action.yaml
+++ b/action.yaml
@@ -58,6 +58,11 @@ inputs:
     required: true
     default: "infracost-config.json"
 
+  environment:
+    description: "GitHub environment name (e.g., 'prod', 'test' or 'devl'). Used for Gist URL construction."
+    required: false
+    default: "${{ github.environment }}"
+
   max-cost:
     description: "Optional cost threshold. Fails if total monthly cost exceeds this amount (e.g., 100.00)."
     required: false
@@ -143,7 +148,7 @@ runs:
         GIST_ID="${{ inputs.gist-id }}"
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}" 
-        ENVIRONMENT="${{ github.environment }}"
+        ENVIRONMENT="${{ inputs.environment }}"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"

--- a/action.yaml
+++ b/action.yaml
@@ -137,6 +137,8 @@ runs:
 
     - name: Download Gist JSON file to get the Infracost configuration (max cost, etc.)
       id: download-gist
+      shell: bash
+      working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
         GIST_ID="${{ inputs.gist-id }}"
         FILENAME="${{ inputs.gist-filename }}"

--- a/action.yaml
+++ b/action.yaml
@@ -171,7 +171,7 @@ runs:
         echo "✅ max_cost resolved: $MAX_COST"
         echo "max_cost=$MAX_COST" >> "$GITHUB_OUTPUT"
 
-        echo "### 💰 Infracost Defined Maxcost (`$ENVIRONMENT`)" >> $GITHUB_STEP_SUMMARY
+        echo "### 💰 Infracost Defined Maxcost ( `${{ inputs.environment }}` )" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         echo "max_cost=$MAX_COST" >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -150,7 +150,7 @@ runs:
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}"
         ENVIRONMENT="${{ inputs.environment }}"
-        REPO_NAME="`echo ${{ github.repository }}|cut -d'/' -f2`"
+        REPO_NAME="`echo ${{ github.repository }}`|cut -d'/' -f2"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"

--- a/action.yaml
+++ b/action.yaml
@@ -1,52 +1,61 @@
-name: 'Infracost Run'
-description: 'Download Terraform plan artifact and run Infracost to generate cost breakdown.'
+name: "Infracost Run"
+description: "Downloads a Terraform plan artifact and runs Infracost to generate a cost breakdown."
 
 inputs:
-  release-tag:
-    description: 'Optional release tag to checkout'
+  terraform-dir:
+    description: "Relative path to the directory containing Terraform configuration files (e.g., 'tf', 'infrastructure')."
     required: false
     type: string
-    default: ''
-
-  terraform-dir:
-    description: "Path to the Terraform configuration"
-    required: false
     default: "tf"
 
+  release-tag:
+    description: "Git release tag to check out. If omitted, the latest commit on the default branch is used."
+    required: false
+    type: string
+    default: ""
+
+  ci-pipeline:
+    description: "Set to 'true' to include the commit SHA in the Terraform state key (suitable for CI/CD). Use 'false' for static state keys."
+    required: false
+    type: string
+    default: "false"
+
   s3-bucket:
-    description: "S3 bucket for Terraform backend"
+    description: "Name of the S3 bucket used as the backend for storing the Terraform state file."
     required: true
+    type: string
 
   s3-region:
-    description: "AWS region where the S3 bucket is located"
+    description: "AWS region where the S3 backend bucket is located (e.g., us-east-1, eu-west-1)."
     required: true
-
-  tf-plan-file:
-    description: "File to save the Terraform plan output"
-    required: false
-    default: "tfplan"  
-
-  tf-vars-file:
-    description: "Optional Terraform variable file"
-    required: false
-    default: "terraform.tfvars"
+    type: string
 
   tf-plan-name:
     description: "Name of the Terraform plan file"
     required: false
     default: "terraform-plan"
 
-  ci-pipeline:
-    description: "Set to true to use commit SHA in backend key"
+  tf-plan-name:
+    description: "Name of the Terraform plan artifact."
     required: false
-    default: "false"
+    default: "terraform-plan"
+
+  tf-plan-file:
+    description: "Base filename (without extension) for the Terraform plan output."
+    required: false
+    default: "tfplan"
+
+  tf-vars-file:
+    description: "Optional Terraform variable file."
+    required: false
+    default: "terraform.tfvars"
 
   infracost-api-key:
-    description: 'Infracost API key'
+    description: "Infracost API key."
     required: true
 
   max-cost:
-    description: "Optional cost threshold. Fail if total monthly cost exceeds this amount (e.g., 100.00)"
+    description: "Optional cost threshold. Fails if total monthly cost exceeds this amount (e.g., 100.00)."
     required: false
     default: "10.00"
 
@@ -56,26 +65,32 @@ outputs:
     value: ${{ steps.infracost-json.outputs.monthly-cost }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Checkout repo
+    - name: Set Checkout Ref
+      id: set-ref
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.release-tag }}" ]]; then
+          echo "ref=${{ inputs.release-tag }}" >> $GITHUB_OUTPUT
+        else
+          echo "ref=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Checkout Repo
+      id: checkout
       uses: actions/checkout@v4
-
-    - name: Download Terraform plan artifact
-      uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.terraform-plan-file }}
-        path: ${{ inputs.tf-plan-name}}
-
-    - name: Setup Infracost
-      uses: infracost/actions/setup@v2
+        ref: ${{ steps.set-ref.outputs.ref }}
 
     - name: Setup Terraform
+      id: setup-terraform
       uses: hashicorp/setup-terraform@v3
 
-    - name: Compute Backend Key from Repository Name
-      id: key
+    - name: Generate Terraform State Key
+      id: generate-tfstate-key
       shell: bash
+      working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
         if [[ "${{ inputs.ci-pipeline }}" == "true" ]]; then
           state_key="${{ github.repository }}/${{ github.sha }}/terraform.tfstate"
@@ -84,18 +99,27 @@ runs:
         fi
         echo "s3_key=$state_key" >> $GITHUB_OUTPUT
 
-    - name: Terraform Init with S3 Backend
+    - name: Initialize Terraform with S3 Backend
+      id: terraform-init-s3
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
         terraform init -input=false \
           -backend-config="bucket=${{ inputs.s3-bucket }}" \
-          -backend-config="key=${{ steps.key.outputs.s3_key }}" \
+          -backend-config="key=${{ steps.generate-tfstate-key.outputs.s3_key }}" \
           -backend-config="region=${{ inputs.s3-region }}" \
           -backend-config="encrypt=true" \
           -backend-config="use_lockfile=true"
 
+    - name: Download Plan Output as Artifact
+      id: download-plan-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.tf-plan-name }}
+        path: ${{ github.workspace }}/${{ inputs.terraform-dir }}
+
     - name: Convert Terraform plan to JSON
+      id: convert-tfplan-json
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -59,9 +59,9 @@ inputs:
     default: "infracost-config.json"
 
   environment:
-    description: "GitHub environment name (e.g., 'prod', 'test' or 'devl'). Used for Gist URL construction."
+    description: "GitHub environment name (e.g., 'prod', 'test', 'devl'). Used to match max cost in Gist."
     required: false
-    default: "${{ github.environment }}"
+    default: "devl"
 
   max-cost:
     description: "Optional cost threshold. Fails if total monthly cost exceeds this amount (e.g., 100.00)."
@@ -72,6 +72,9 @@ outputs:
   monthly-cost:
     description: "Total monthly cost from Infracost"
     value: ${{ steps.infracost-json.outputs.monthly-cost }}
+  max-cost:
+    description: "The max cost retrieved from the Gist (or fallback value)"
+    value: ${{ steps.download-gist.outputs.max_cost }}
 
 runs:
   using: "composite"
@@ -87,13 +90,11 @@ runs:
         fi
 
     - name: Checkout Repo
-      id: checkout
       uses: actions/checkout@v4
       with:
         ref: ${{ steps.set-ref.outputs.ref }}
 
     - name: Setup Terraform
-      id: setup-terraform
       uses: hashicorp/setup-terraform@v3
 
     - name: Generate Terraform State Key
@@ -109,7 +110,6 @@ runs:
         echo "s3_key=$state_key" >> $GITHUB_OUTPUT
 
     - name: Initialize Terraform with S3 Backend
-      id: terraform-init-s3
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
@@ -121,21 +121,22 @@ runs:
           -backend-config="use_lockfile=true"
 
     - name: Download Plan Output as Artifact
-      id: download-plan-artifact
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.tf-plan-name }}
         path: ${{ github.workspace }}/${{ inputs.terraform-dir }}
 
     - name: Convert Terraform plan to JSON
-      id: convert-tfplan-json
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
         terraform show -json ${{ inputs.tf-plan-file }}.out > ${{ inputs.tf-plan-file }}.json
-        echo "----------- Terraform plan converted to JSON -----------"
-        cat ${{ inputs.tf-plan-file }}.json | jq
-        echo "---------------------------------------------------------"
+
+    - name: Upload Terraform Plan JSON as Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.tf-plan-name }}-json
+        path: ${{ github.workspace }}/${{ inputs.terraform-dir }}/${{ inputs.tf-plan-file }}.json
 
     - name: Setup Infracost
       uses: infracost/actions/setup@v2
@@ -147,16 +148,29 @@ runs:
       run: |
         GIST_ID="${{ inputs.gist-id }}"
         FILENAME="${{ inputs.gist-filename }}"
-        USERNAME="${{ github.actor }}" 
+        USERNAME="${{ github.actor }}"
         ENVIRONMENT="${{ inputs.environment }}"
+        REPO_NAME="${{ github.repository }}"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"
-        
         curl -sSL "$GIST_URL" -o gist.json
+        echo "Downloaded Gist JSON:"
         cat gist.json
-        echo "-------------------------"
+
         echo "Environment: $ENVIRONMENT"
+        echo "Repository: $REPO_NAME"
+
+        MAX_COST=$(jq -r --arg repo "$REPO_NAME" --arg env "$ENVIRONMENT" \
+          '.[] | select(.repository == $repo and .environment == $env) | .max_cost' gist.json)
+
+        if [[ -z "$MAX_COST" || "$MAX_COST" == "null" ]]; then
+          echo "⚠️ max_cost not found for $REPO_NAME in $ENVIRONMENT. Using fallback value 9.99"
+          MAX_COST="9.99"
+        fi
+
+        echo "✅ max_cost resolved: $MAX_COST"
+        echo "max_cost=$MAX_COST" >> "$GITHUB_OUTPUT"
 
     - name: Run Infracost (JSON)
       id: infracost-json
@@ -165,6 +179,9 @@ runs:
       env:
         INFRACOST_API_KEY: ${{ inputs.infracost-api-key }}
       run: |
+        MAX_COST="${{ steps.download-gist.outputs.max_cost }}"
+        echo "Using max_cost: $MAX_COST"
+
         infracost breakdown \
           --path=${{ inputs.tf-plan-file }}.json \
           --format=json \
@@ -174,8 +191,10 @@ runs:
         monthly_cost=$(jq -r '.summary.totalMonthlyCost // "0"' cost-report.json)
         printf "monthly-cost=%.2f\n" "$monthly_cost" >> $GITHUB_OUTPUT
 
-        if [[ -n "${{ inputs.max-cost }}" ]]; then
-          max=$(echo "${{ inputs.max-cost }}" | awk '{ printf "%.2f", $1 }')
+        echo "Monthly cost from Infracost: $monthly_cost"
+
+        if [[ -n "$MAX_COST" ]]; then
+          max=$(echo "$MAX_COST" | awk '{ printf "%.2f", $1 }')
           if (( $(echo "$monthly_cost > $max" | bc -l) )); then
             echo "❌ Monthly cost ($monthly_cost) exceeds max threshold ($max)"
             exit 1
@@ -183,7 +202,6 @@ runs:
         fi
 
     - name: Append Infracost Table Summary
-      id: infracost-table
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -172,6 +172,12 @@ runs:
         echo "✅ max_cost resolved: $MAX_COST"
         echo "max_cost=$MAX_COST" >> "$GITHUB_OUTPUT"
 
+        echo "### 💰 Infracost Defined Maxcost" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "max_cost=$MAX_COST" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
     - name: Run Infracost (JSON)
       id: infracost-json
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -2,12 +2,7 @@ name: 'Infracost Run'
 description: 'Download Terraform plan artifact and run Infracost to generate cost breakdown.'
 
 inputs:
-  artifact-name:
-    description: 'Name of the uploaded Terraform plan artifact'
-    required: true
-    default: 'terraform-plan'
-
-  release_tag:
+  release-tag:
     description: 'Optional release tag to checkout'
     required: false
     type: string
@@ -18,11 +13,6 @@ inputs:
     required: false
     default: "tf"
 
-  tf-vars-file:
-    description: "Optional Terraform variable file"
-    required: false
-    default: "terraform.tfvars"
-
   s3-bucket:
     description: "S3 bucket for Terraform backend"
     required: true
@@ -31,15 +21,25 @@ inputs:
     description: "AWS region where the S3 bucket is located"
     required: true
 
+  tf-plan-file:
+    description: "File to save the Terraform plan output"
+    required: false
+    default: "tfplan"  
+
+  tf-vars-file:
+    description: "Optional Terraform variable file"
+    required: false
+    default: "terraform.tfvars"
+
+  tf-plan-name:
+    description: "Name of the Terraform plan file"
+    required: false
+    default: "terraform-plan"
+
   ci-pipeline:
     description: "Set to true to use commit SHA in backend key"
     required: false
-    default: "false"  # Boolean-like string
-
-  terraform-plan-file:
-    description: 'Path to the Terraform binary plan file inside the artifact'
-    required: true
-    default: 'tfplan.out'
+    default: "false"
 
   infracost-api-key:
     description: 'Infracost API key'
@@ -64,8 +64,8 @@ runs:
     - name: Download Terraform plan artifact
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.artifact-name }}
-        path: plan-artifact
+        name: ${{ inputs.terraform-plan-file }}
+        path: ${{ inputs.tf-plan-name}}
 
     - name: Setup Infracost
       uses: infracost/actions/setup@v2
@@ -99,10 +99,9 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
       run: |
-        cp ../plan-artifact/${{ inputs.terraform-plan-file }} tfplan.out
-        terraform show -json tfplan.out > plan.json
+        terraform show -json ${{ inputs.tf-plan-file }}.out > ${{ inputs.tf-plan-file }}.json
         echo "----------- Terraform plan converted to JSON -----------"
-        cat plan.json | jq
+        cat ${{ inputs.tf-plan-file }}.json | jq
         echo "---------------------------------------------------------"
 
     - name: Run Infracost (JSON)
@@ -113,7 +112,7 @@ runs:
         INFRACOST_API_KEY: ${{ inputs.infracost-api-key }}
       run: |
         infracost breakdown \
-          --path=plan.json \
+          --path=${{ inputs.tf-plan-file }}.json \
           --format=json \
           --log-level=info \
           --out-file=cost-report.json
@@ -137,7 +136,7 @@ runs:
         INFRACOST_API_KEY: ${{ inputs.infracost-api-key }}
       run: |
         infracost breakdown \
-          --path=plan.json \
+          --path=${{ inputs.tf-plan-file }}.json \
           --format=table \
           --log-level=info > cost-table.txt
 

--- a/action.yaml
+++ b/action.yaml
@@ -63,17 +63,12 @@ inputs:
     required: false
     default: "devl"
 
-  max-cost:
-    description: "Optional cost threshold. Fails if total monthly cost exceeds this amount (e.g., 100.00)."
-    required: false
-    default: "10.00"
-
 outputs:
   monthly-cost:
     description: "Total monthly cost from Infracost"
     value: ${{ steps.infracost-json.outputs.monthly-cost }}
   max-cost:
-    description: "The max cost retrieved from the Gist (or fallback value)"
+    description: "Maximum cost threshold from Gist or fallback"
     value: ${{ steps.download-gist.outputs.max_cost }}
 
 runs:
@@ -149,7 +144,7 @@ runs:
         GIST_ID="${{ inputs.gist-id }}"
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}"
-        ENVIRONMENT="${{ inputs.environment }}"
+        ENVIRONMENT="$(echo "${{ inputs.environment }}" | tr '[:upper:]' '[:lower:]')"
         REPO_NAME="$(echo "${{ github.repository }}" | cut -d'/' -f2)"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
@@ -171,7 +166,7 @@ runs:
         echo "✅ max_cost resolved: $MAX_COST"
         echo "max_cost=$MAX_COST" >> "$GITHUB_OUTPUT"
 
-        echo "### 💰 Infracost Defined Maxcost " >> $GITHUB_STEP_SUMMARY
+        echo "### 💰 Infracost Defined Max Cost" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         echo "max_cost=$MAX_COST ($ENVIRONMENT)" >> $GITHUB_STEP_SUMMARY
@@ -184,6 +179,8 @@ runs:
       env:
         INFRACOST_API_KEY: ${{ inputs.infracost-api-key }}
       run: |
+        command -v bc >/dev/null 2>&1 || { echo >&2 "❌ 'bc' is required but not installed."; exit 1; }
+
         MAX_COST="${{ steps.download-gist.outputs.max_cost }}"
         echo "Using max_cost: $MAX_COST"
 

--- a/action.yaml
+++ b/action.yaml
@@ -123,6 +123,9 @@ runs:
         cat ${{ inputs.tf-plan-file }}.json | jq
         echo "---------------------------------------------------------"
 
+    - name: Setup Infracost
+      uses: infracost/actions/setup@v2
+
     - name: Run Infracost (JSON)
       id: infracost-json
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -171,7 +171,7 @@ runs:
         echo "✅ max_cost resolved: $MAX_COST"
         echo "max_cost=$MAX_COST" >> "$GITHUB_OUTPUT"
 
-        echo "### 💰 Infracost Defined Maxcost" >> $GITHUB_STEP_SUMMARY
+        echo "### 💰 Infracost Defined Maxcost (`$ENVIRONMENT`)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         echo "max_cost=$MAX_COST" >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,22 @@ inputs:
     required: true
     default: 'terraform-plan'
 
+  release_tag:
+    description: 'Optional release tag to checkout'
+    required: false
+    type: string
+    default: ''
+
+  terraform-dir:
+    description: "Path to the Terraform configuration"
+    required: false
+    default: "tf"
+
+  tf-vars-file:
+    description: "Optional Terraform variable file"
+    required: false
+    default: "terraform.tfvars"
+
   s3-bucket:
     description: "S3 bucket for Terraform backend"
     required: true
@@ -15,24 +31,15 @@ inputs:
     description: "AWS region where the S3 bucket is located"
     required: true
 
-  dynamodb-table:
-    description: "DynamoDB table name for state locking"
-    required: true
+  ci-pipeline:
+    description: "Set to true to use commit SHA in backend key"
+    required: false
+    default: "false"  # Boolean-like string
 
   terraform-plan-file:
     description: 'Path to the Terraform binary plan file inside the artifact'
     required: true
     default: 'tfplan.out'
-
-  terraform-dir:
-    description: 'Directory where Terraform code is located'
-    required: false
-    default: 'tf'
-
-  ci-pipeline:
-    description: "Whether this is a CI pipeline"
-    required: false
-    default: "true"
 
   infracost-api-key:
     description: 'Infracost API key'
@@ -86,7 +93,7 @@ runs:
           -backend-config="key=${{ steps.key.outputs.s3_key }}" \
           -backend-config="region=${{ inputs.s3-region }}" \
           -backend-config="encrypt=true" \
-          -backend-config="dynamodb_table=${{ inputs.dynamodb-table }}"
+          -backend-config="use_lockfile=true"
 
     - name: Convert Terraform plan to JSON
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -31,11 +31,6 @@ inputs:
     type: string
 
   tf-plan-name:
-    description: "Name of the Terraform plan file"
-    required: false
-    default: "terraform-plan"
-
-  tf-plan-name:
     description: "Name of the Terraform plan artifact."
     required: false
     default: "terraform-plan"

--- a/action.yaml
+++ b/action.yaml
@@ -143,7 +143,7 @@ runs:
         GIST_ID="${{ inputs.gist-id }}"
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}" 
-        ENVIRONMENT="${{ ${{ github.environment }}"
+        ENVIRONMENT="${{ github.environment }}"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"

--- a/action.yaml
+++ b/action.yaml
@@ -143,12 +143,15 @@ runs:
         GIST_ID="${{ inputs.gist-id }}"
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}" 
+        ENVIRONMENT="${{ ${{ github.environment }}"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"
         
         curl -sSL "$GIST_URL" -o gist.json
         cat gist.json
+        echo "-------------------------"
+        echo "Environment: $ENVIRONMENT"
 
     - name: Run Infracost (JSON)
       id: infracost-json

--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,15 @@ inputs:
     description: "Infracost API key."
     required: true
 
+  gist-id:
+    description: "Gist ID containing the Infracost configuration (e.g., max cost)."
+    required: true
+
+  gist-filename:
+    description: "Filename of the Gist containing the Infracost configuration (e.g., 'infracost-config.json')."
+    required: true
+    default: "infracost-config.json"
+
   max-cost:
     description: "Optional cost threshold. Fails if total monthly cost exceeds this amount (e.g., 100.00)."
     required: false
@@ -125,6 +134,19 @@ runs:
 
     - name: Setup Infracost
       uses: infracost/actions/setup@v2
+
+    - name: Download Gist JSON file to get the Infracost configuration (max cost, etc.)
+      id: download-gist
+      run: |
+        GIST_ID="${{ inputs.gist-id }}"
+        FILENAME="${{ inputs.gist-filename }}"
+        USERNAME="${{ github.actor }}" 
+
+        GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
+        echo "Fetching Gist from: $GIST_URL"
+        
+        curl -sSL "$GIST_URL" -o gist.json
+        cat gist.json
 
     - name: Run Infracost (JSON)
       id: infracost-json

--- a/action.yaml
+++ b/action.yaml
@@ -150,7 +150,7 @@ runs:
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}"
         ENVIRONMENT="${{ inputs.environment }}"
-        REPO_NAME="${{ github.repository }}"
+        REPO_NAME="echo ${{ github.repository }}|cut -d'/' -f2"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"

--- a/action.yaml
+++ b/action.yaml
@@ -150,7 +150,7 @@ runs:
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}"
         ENVIRONMENT="${{ inputs.environment }}"
-        REPO_NAME="echo ${{ github.repository }}|cut -d'/' -f2"
+        REPO_NAME="`echo ${{ github.repository }}|cut -d'/' -f2`"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"

--- a/action.yaml
+++ b/action.yaml
@@ -150,7 +150,7 @@ runs:
         FILENAME="${{ inputs.gist-filename }}"
         USERNAME="${{ github.actor }}"
         ENVIRONMENT="${{ inputs.environment }}"
-        REPO_NAME="`echo ${{ github.repository }}`|cut -d'/' -f2"
+        REPO_NAME="$(echo "${{ github.repository }}" | cut -d'/' -f2)"
 
         GIST_URL="https://gist.githubusercontent.com/$USERNAME/$GIST_ID/raw/$FILENAME"
         echo "Fetching Gist from: $GIST_URL"

--- a/action.yaml
+++ b/action.yaml
@@ -161,8 +161,7 @@ runs:
         echo "Environment: $ENVIRONMENT"
         echo "Repository: $REPO_NAME"
 
-        MAX_COST=$(jq -r --arg repo "$REPO_NAME" --arg env "$ENVIRONMENT" \
-          '.[] | select(.repository == $repo and .environment == $env) | .max_cost' gist.json)
+        MAX_COST=$(jq -r --arg repo "$REPO_NAME" --arg env "$ENVIRONMENT" '.[$repo][$env].max_cost' gist.json)
 
         if [[ -z "$MAX_COST" || "$MAX_COST" == "null" ]]; then
           echo "⚠️ max_cost not found for $REPO_NAME in $ENVIRONMENT. Using fallback value 9.99"

--- a/action.yaml
+++ b/action.yaml
@@ -171,10 +171,10 @@ runs:
         echo "✅ max_cost resolved: $MAX_COST"
         echo "max_cost=$MAX_COST" >> "$GITHUB_OUTPUT"
 
-        echo "### 💰 Infracost Defined Maxcost ( `${{ inputs.environment }}` )" >> $GITHUB_STEP_SUMMARY
+        echo "### 💰 Infracost Defined Maxcost " >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
-        echo "max_cost=$MAX_COST" >> $GITHUB_STEP_SUMMARY
+        echo "max_cost=$MAX_COST ($ENVIRONMENT)" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
 
     - name: Run Infracost (JSON)


### PR DESCRIPTION
This pull request significantly enhances the functionality and documentation of the Infracost GitHub Action. Key changes include updates to the `README.md` for improved clarity and detail, revisions to `action.yaml` to support new inputs and outputs, and modifications to the action's workflow to enable dynamic cost thresholding using a GitHub Gist.

### Documentation Improvements:
* Updated `README.md` to provide a detailed overview of the Infracost GitHub Action, including its purpose, supported features, and configuration options. Added sections for inputs, outputs, example usage, and a sample Gist JSON format for dynamic cost thresholding.

### Enhanced Action Configuration:
* Added new inputs in `action.yaml`, such as `terraform-dir`, `release-tag`, `gist-id`, and `gist-filename`, to improve flexibility in configuring the action. These inputs allow users to define Terraform directories, specify Git release tags, and dynamically fetch cost thresholds from a Gist.
* Introduced new outputs (`monthly-cost` and `max-cost`) to provide actionable results from the Infracost analysis, including the calculated monthly cost and the resolved maximum cost threshold.

### Workflow Enhancements:
* Modified the workflow in `action.yaml` to dynamically fetch and resolve cost thresholds from a GitHub Gist. This includes downloading the Gist JSON file, parsing it for environment-specific cost limits, and using the resolved threshold in the cost analysis.
* Improved the Terraform initialization and artifact handling steps, including generating a Terraform state key dynamically and uploading the JSON output of the Terraform plan as an artifact.

### Cost Analysis Logic:
* Updated the Infracost execution logic to compare the calculated monthly cost against the dynamically resolved maximum cost threshold. Added validation to ensure the `bc` utility is installed for cost comparison.