### PR TITLE
fix: update checkout step to use dynamic ref output

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -85,8 +85,10 @@ runs:
         fi
 
     - name: Checkout Repo
+      id: checkout
       uses: actions/checkout@v4
       with:
+        ref: ${{ steps.set-ref.outputs.ref }}
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This pull request makes a small improvement to the `action.yaml` file by adding an `id` to the `Checkout Repo` step and specifying a `ref` for the checkout action. These changes enhance the configurability and clarity of the workflow.