### PR TITLE
bug: Add step to install 'bc' for Linux runners

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -173,6 +173,13 @@ runs:
         echo "max_cost=$MAX_COST ($ENVIRONMENT)" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
 
+    - name: Install bc
+      id: install-bc
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update && sudo apt-get install -y bc
+
     - name: Run Infracost (JSON)
       id: infracost-json
       shell: bash


### PR DESCRIPTION
This pull request introduces a small but necessary change to the `action.yaml` file, ensuring the required `bc` tool is installed on Linux runners.

* **Dependency Installation**:
  - Added a new step to install the `bc` utility using `apt-get` on Linux runners to ensure compatibility with subsequent steps. (`[action.yamlR176-R182](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR176-R182)`)